### PR TITLE
Generated a template for dockerized Lambda function

### DIFF
--- a/.github/workflows/terraform-apply-dispatched.yml
+++ b/.github/workflows/terraform-apply-dispatched.yml
@@ -1,0 +1,38 @@
+name: "Dispatched Terraform Apply"
+
+on:
+  repository_dispatch:
+
+jobs:
+
+  merge-trigger:
+    if: github.ref == 'refs/heads/test-lambda-deploy-from-image'"
+    name: "terraform-apply"
+    strategy:
+      max-parallel: 1
+      matrix:
+        environment: [dev]
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    environment: ${{ matrix.environment }}
+    permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        env:
+          AWS_REGION: eu-south-1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Apply
+        uses: ./.github/workflows/apply
+        with:
+          env: ${{ matrix.environment }}
+          working-directory: src/lambdatemplate

--- a/.github/workflows/terraform-apply-dispatched.yml
+++ b/.github/workflows/terraform-apply-dispatched.yml
@@ -2,19 +2,22 @@ name: "Dispatched Terraform Apply"
 
 on:
   repository_dispatch:
+    types: ["terraform-apply-dispatched"]
+
+env:
+  ENVIRONMENT: ${{ github.event.client_payload.environment }}
+  DOMAIN: ${{ github.event.client_payload.domain }}
 
 jobs:
 
   merge-trigger:
-    if: github.ref == 'refs/heads/test-lambda-deploy-from-image'"
+    if: github.ref == 'refs/heads/main'
     name: "terraform-apply"
     strategy:
       max-parallel: 1
-      matrix:
-        environment: [dev]
     runs-on: ubuntu-latest
     continue-on-error: false
-    environment: ${{ matrix.environment }}
+    environment: ${{ env.ENVIRONMENT }}
     permissions:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
@@ -34,5 +37,5 @@ jobs:
       - name: Apply
         uses: ./.github/workflows/apply
         with:
-          env: ${{ matrix.environment }}
-          working-directory: src/lambdatemplate
+          env: ${{ env.ENVIRONMENT }}
+          working-directory: src/${{ env.DOMAIN }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,13 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
 
+*.DS_Store
+*.log
+*.h2.db
+settings.json
+__TMP
+.metals/
+/.idea
 
 # zip files
 *.zip

--- a/src/lambdatemplate/.terraform.lock.hcl
+++ b/src/lambdatemplate/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.44.0"
+  constraints = "~> 4.44.0"
+  hashes = [
+    "h1:IicMBt+WvFATiN4j/oaJYB4Kvk6LCxxpnokv2PXo1ag=",
+    "zh:08da139140530900ebb07baedd9044b5002f0296f5f160d96783e72080158326",
+    "zh:2d677b9e4f195481098cec843d0138f3a198f1f93be42c1d1654b71438e2f5ab",
+    "zh:3cdf4e06b9b8f30f6652a4519d586febc4ab92168a39df2610f06e04a8e6dda7",
+    "zh:677933957d1de40c8b5ae252c5cd369617af4cb7a26e8f750ad6f175fef4f767",
+    "zh:6a266ae5488d6daa53bbe6c2cb8368833381eacd9de7f05f059f5100535a0cb2",
+    "zh:6cdccaab0a444314b10246c8d58b0ffb84d32ddac70e36a12b45eb518e0ae065",
+    "zh:6ed49c7680298761416d408bc91cd137ae7cff38181fc143b1dfab1a32b44516",
+    "zh:8403a0fbf439009b3b0c77969c560cf426aeb3d99a78fdd27afbf4694ca0f3e7",
+    "zh:8ddfd85c6789bca7c66346da1f3488488c20bc4d773cd26669059c437cfbabd6",
+    "zh:941455d0fa54b0451387cfd611d63766f4b18cb24038f25ee0794097755e654d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bc01398c714d621ad9f4e81863446cd8e1135a63a5ff7c36d3fb01ab27e96439",
+    "zh:ce3b39a43b9c5b34a62047fe2a395b72a62cc0b5dc7e8a5be0f778159ac486d2",
+    "zh:d5891b82511af25570287578318aaee4fa86e05599cc8c81d44ea9e094f4a728",
+    "zh:df5329c186545d273f9abaeeb39251d6cfcc446bccc44e27d1d7d02ebf145e2f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+  hashes = [
+    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}

--- a/src/lambdatemplate/.terraform.lock.hcl
+++ b/src/lambdatemplate/.terraform.lock.hcl
@@ -23,22 +23,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:df5329c186545d273f9abaeeb39251d6cfcc446bccc44e27d1d7d02ebf145e2f",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.1"
-  hashes = [
-    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
-    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
-    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
-    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
-    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
-    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
-    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
-    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
-    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
-    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
-    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
-  ]
-}

--- a/src/lambdatemplate/00-main.tf
+++ b/src/lambdatemplate/00-main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = "~> 1.3.0"
+
+  # TODO Uncomment once the backend S3 bucket is created and upload the state file.
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.44.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_availability_zones" "available" {}

--- a/src/lambdatemplate/02-security.tf
+++ b/src/lambdatemplate/02-security.tf
@@ -15,8 +15,44 @@ resource "aws_iam_role" "lambdatemplate_iam_role" {
   })
 }
 
+# Resource related to the IAM role used for the access to the ECR in order to push images on ECR
+resource "aws_iam_role" "lambdatemplate_ecraccess_iam_role" {
+  name = "lambdatemplate_ecraccess"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        "Federated" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+      },
+      Action = "sts:AssumeRoleWithWebIdentity",
+      Condition = {
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" : "repo:${var.github_lambda_repository}:*"
+        },
+        "ForAllValues:StringEquals" = {
+          "token.actions.githubusercontent.com:iss" : "https://token.actions.githubusercontent.com",
+          "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
+        }
+      }
+    }
+    ]
+  })
+}
+
 # Resource related to the policy associated to the lambda function's role
 resource "aws_iam_role_policy_attachment" "lambda_policy" {
   role       = aws_iam_role.lambdatemplate_iam_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Resource related to the policy associated to the full access to ECR for pushing the new images
+resource "aws_iam_role_policy_attachment" "lambdatemplate_ecr_full_access" {
+  role       = aws_iam_role.lambdatemplate_ecraccess_iam_role.name
+  policy_arn = data.aws_iam_policy.ec2_ecr_full_access.arn
+}
+
+# Resource related to the policy associated to the full access to EC2 ECR
+data "aws_iam_policy" "ec2_ecr_full_access" {
+  name = "AmazonEC2ContainerRegistryFullAccess"
 }

--- a/src/lambdatemplate/02-security.tf
+++ b/src/lambdatemplate/02-security.tf
@@ -1,0 +1,22 @@
+# Resource related to the IAM role used by the lambda function
+resource "aws_iam_role" "lambdatemplate_iam_role" {
+  name = "serverless_lambdatemplate"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Sid    = ""
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }
+    ]
+  })
+}
+
+# Resource related to the policy associated to the lambda function's role
+resource "aws_iam_role_policy_attachment" "lambda_policy" {
+  role       = aws_iam_role.lambdatemplate_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/src/lambdatemplate/05-locals.tf
+++ b/src/lambdatemplate/05-locals.tf
@@ -1,0 +1,9 @@
+locals {
+  account_id                = data.aws_caller_identity.current.account_id
+  project                   = format("%s-%s-%s", var.prefix, var.app_name, var.env_short)
+  ecr_url                   = format("%s.dkr.ecr.%s.amazonaws.com", local.account_id, var.aws_region)
+  ecr_repository_name       = format("%s%s%s", var.prefix, var.env_short, var.app_name)
+  ecr_repository_url        = format("%s/%s", local.ecr_url, local.ecr_repository_name)
+  ecr_image_tag             = "latest"
+  lambda_invocation_auth    = "NONE"
+}

--- a/src/lambdatemplate/05-locals.tf
+++ b/src/lambdatemplate/05-locals.tf
@@ -1,6 +1,6 @@
 locals {
   account_id                = data.aws_caller_identity.current.account_id
-  project                   = format("%s-%s-%s", var.prefix, var.app_name, var.env_short)
+  project                   = format("%s-%s-%s", var.prefix, var.env_short, var.app_name)
   ecr_url                   = format("%s.dkr.ecr.%s.amazonaws.com", local.account_id, var.aws_region)
   ecr_repository_name       = format("%s%s%s", var.prefix, var.env_short, var.app_name)
   ecr_repository_url        = format("%s/%s", local.ecr_url, local.ecr_repository_name)

--- a/src/lambdatemplate/10-ecr.tf
+++ b/src/lambdatemplate/10-ecr.tf
@@ -1,0 +1,14 @@
+# Resource related to the container registry repository
+resource "aws_ecr_repository" "lambdatemplate_ecr" {
+  name                 = local.ecr_repository_name
+  image_tag_mutability = var.image_tag_mutability
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# Data related to Docker lambda image
+data "aws_ecr_image" "lambdatemplate_image" {
+  repository_name = aws_ecr_repository.lambdatemplate_ecr.name
+  image_tag       = local.ecr_image_tag
+}

--- a/src/lambdatemplate/10-lambda.tf
+++ b/src/lambdatemplate/10-lambda.tf
@@ -1,22 +1,3 @@
-# Provisioner for login on AWS ECR resources
-resource "null_resource" "container_registry_login" {
-  provisioner "local-exec" {
-    command = <<EOF
-                aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${local.ecr_url}
-                EOF
-    interpreter = ["bash", "-c"]
-  }
-}
-
-# Data related to Docker lambda image
-data "aws_ecr_image" "lambdatemplate_image" {
-  depends_on = [
-    null_resource.container_registry_login
-  ]
-  repository_name = local.ecr_repository_name
-  image_tag       = local.ecr_image_tag
-}
-
 # Resource related to the lambda function
 resource "aws_lambda_function" "lambdatemplate" {
   function_name    = "lambdatemplate-${var.env_short}-lambda"

--- a/src/lambdatemplate/10-lambda.tf
+++ b/src/lambdatemplate/10-lambda.tf
@@ -1,0 +1,45 @@
+# Provisioner for login on AWS ECR resources
+resource "null_resource" "container_registry_login" {
+  provisioner "local-exec" {
+    command = <<EOF
+                aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${local.ecr_url}
+                EOF
+    interpreter = ["bash", "-c"]
+  }
+}
+
+# Data related to Docker lambda image
+data "aws_ecr_image" "lambdatemplate_image" {
+  depends_on = [
+    null_resource.container_registry_login
+  ]
+  repository_name = local.ecr_repository_name
+  image_tag       = local.ecr_image_tag
+}
+
+# Resource related to the lambda function
+resource "aws_lambda_function" "lambdatemplate" {
+  function_name    = "lambdatemplate-${var.env_short}-lambda"
+  role             = aws_iam_role.lambdatemplate_iam_role.arn
+  timeout          = 300
+  image_uri        = format("%s@%s", local.ecr_repository_url, data.aws_ecr_image.lambdatemplate_image.id)
+  package_type     = "Image"
+}
+
+# Resource related to the lambda function's URL
+resource "aws_lambda_function_url" "lambdatemplate_latest" {
+  depends_on = [
+    aws_lambda_function.lambdatemplate
+  ]
+  function_name      = aws_lambda_function.lambdatemplate.function_name
+  authorization_type = local.lambda_invocation_auth
+}
+
+# Resource related to the CloudWatch log system used by lambda function
+resource "aws_cloudwatch_log_group" "lambdatemplate" {
+  depends_on = [
+    aws_lambda_function.lambdatemplate
+  ]
+  name = "/aws/lambda/${aws_lambda_function.lambdatemplate.function_name}"
+  retention_in_days = var.lambda_log_retention
+}

--- a/src/lambdatemplate/98-variables.tf
+++ b/src/lambdatemplate/98-variables.tf
@@ -28,6 +28,12 @@ variable "github_lambda_repository" {
   description = "GitHub repository related to the Lambda function project"
 }
 
+variable "image_tag_mutability" {
+  type        = string
+  default     = "MUTABLE"
+  description = "Image mutability for container registry"
+}
+
 variable "lambda_log_retention" {
   type        = number
   default     = 30

--- a/src/lambdatemplate/98-variables.tf
+++ b/src/lambdatemplate/98-variables.tf
@@ -1,0 +1,42 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region used to create resources. Default: Milan"
+  default     = "eu-south-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application name"
+  default     = "lambdatemplate"
+}
+
+variable "environment" {
+  type        = string
+  default     = "dev"
+  description = "Deploy environment"
+}
+
+variable "env_short" {
+  type        = string
+  default     = "d"
+  description = "Abbreviation for deploy environment"
+}
+
+variable "lambda_log_retention" {
+  type        = number
+  default     = 30
+  description = "Retention days for lambda function's logs"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Application platform prefix"
+  default     = "pagopa"
+}
+
+variable "tags" {
+  type = map(any)
+  default = {
+    CreatedBy = "Terraform"
+  }
+}

--- a/src/lambdatemplate/98-variables.tf
+++ b/src/lambdatemplate/98-variables.tf
@@ -1,13 +1,13 @@
 variable "aws_region" {
   type        = string
-  description = "AWS region used to create resources. Default: Milan"
   default     = "eu-south-1"
+  description = "AWS region used to create resources. Default: Milan"
 }
 
 variable "app_name" {
   type        = string
-  description = "Application name"
   default     = "lambdatemplate"
+  description = "Application name"
 }
 
 variable "environment" {
@@ -22,6 +22,12 @@ variable "env_short" {
   description = "Abbreviation for deploy environment"
 }
 
+variable "github_lambda_repository" {
+  type        = string
+  default     = "pagopa/pagopa-aws-lambda-template"
+  description = "GitHub repository related to the Lambda function project"
+}
+
 variable "lambda_log_retention" {
   type        = number
   default     = 30
@@ -30,8 +36,8 @@ variable "lambda_log_retention" {
 
 variable "prefix" {
   type        = string
-  description = "Application platform prefix"
   default     = "pagopa"
+  description = "Application platform prefix"
 }
 
 variable "tags" {

--- a/src/lambdatemplate/99-outputs.tf
+++ b/src/lambdatemplate/99-outputs.tf
@@ -1,0 +1,7 @@
+output "lambdatemplate_function_name" {
+  value = aws_lambda_function.lambdatemplate.function_name
+}
+
+output "lambdatemplate_function_url" {
+  value = aws_lambda_function_url.lambdatemplate_latest.function_url
+}

--- a/src/lambdatemplate/env/dev/backend.tfvars
+++ b/src/lambdatemplate/env/dev/backend.tfvars
@@ -1,0 +1,4 @@
+bucket         = "terraform-backend-5377"
+key            = "dev/lambdatemplate/tfstate"
+region         = "eu-south-1"
+dynamodb_table = "terraform-lock"

--- a/src/lambdatemplate/env/dev/terraform.tfvars
+++ b/src/lambdatemplate/env/dev/terraform.tfvars
@@ -1,0 +1,11 @@
+env_short   = "d"
+environment = "dev"
+
+# Ref: https://pagopa.atlassian.net/wiki/spaces/DEVOPS/pages/132810155/Azure+-+Naming+Tagging+Convention#Tagging
+tags = {
+  CreatedBy   = "Terraform"
+  Environment = "Dev"
+  Owner       = "pagopa-aws-lambda-template"
+  Source      = "https://github.com/pagopa/pagopa-aws-lambda-template.git"
+  CostCenter  = "TS310 - PAGAMENTI e SERVIZI"
+}

--- a/src/lambdatemplate/terraform.sh
+++ b/src/lambdatemplate/terraform.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+action=$1
+env=$2
+shift 2
+other=$@
+
+if [ -z "$action" ]; then
+  echo "Missed action: init, apply, plan"
+  exit 0
+fi
+
+if [ -z "$env" ]; then
+  echo "env should be: dev, uat or prod."
+  exit 0
+fi
+
+if echo "init plan apply refresh import output state taint destroy" | grep -w $action > /dev/null; then
+  if [ $action = "init" ]; then
+    terraform $action -backend-config="./env/$env/backend.tfvars" $other
+  elif [ $action = "output" ] || [ $action = "state" ] || [ $action = "taint" ]; then
+    # init terraform backend
+    terraform init -reconfigure -backend-config="./env/$env/backend.tfvars"
+    terraform $action $other
+  else
+    # init terraform backend
+    terraform init -reconfigure -backend-config="./env/$env/backend.tfvars"
+    terraform $action -var-file="./env/$env/terraform.tfvars" $other
+  fi
+else
+    echo "Action not allowed."
+    exit 1
+fi


### PR DESCRIPTION
With this pull request, some new resources related to a template for a Lambda function are added. This template is made in order to define a guideline for a next definition of a lambda function with Docker image.  
Also, is added a new GitHub Action that permits to the Terraform `apply` command to be triggered for a certain domain by a remote repository, in order to update automatically the Lambda function to acquire the new Docker image pushed in ECR.

**Note:**
This template can be deleted when one or more dockerized Lambda function are added to the infrastructure.

### List of changes
 - Added several resources that generate a template for dockerized Lambda function
 - Added new GitHub Action triggerable by repository for update Lambda's associated Docker image

### Motivation and context
This changes are required in order to define a guideline for future implementations of dockerized Lambda functions.

### Type of changes
- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply
- [x] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
